### PR TITLE
Module for a ContentResolver wrapper

### DIFF
--- a/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/SqlBriteContentProviderTests.java
+++ b/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/SqlBriteContentProviderTests.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqlbrite;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.test.ProviderTestCase2;
+import android.test.mock.MockContentProvider;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import rx.Subscription;
+import rx.subscriptions.Subscriptions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public final class SqlBriteContentProviderTests
+    extends ProviderTestCase2<SqlBriteContentProviderTests.TestContentProvider> {
+  private static final Uri AUTHORITY = Uri.parse("content://test_authority");
+  private static final Uri TABLE = AUTHORITY.buildUpon().appendPath("test_table").build();
+  private static final String KEY = "test_key";
+  private static final String VALUE = "test_value";
+
+  private final RecordingObserver o = new RecordingObserver();
+
+  private ContentResolver contentResolver;
+  private SqlBriteContentProvider db;
+  private Subscription subscription;
+
+  public SqlBriteContentProviderTests() {
+    super(TestContentProvider.class, AUTHORITY.getAuthority());
+  }
+
+  @Override protected void setUp() throws Exception {
+    super.setUp();
+    contentResolver = getMockContentResolver();
+    db = SqlBriteContentProvider.create(contentResolver);
+    getProvider().init(getContext().getContentResolver());
+    db.setLoggingEnabled(true);
+    subscription = Subscriptions.empty();
+  }
+
+  @Override public void tearDown() {
+    o.assertNoMoreEvents();
+    subscription.unsubscribe();
+  }
+
+  public void testLoggerInvalidValues() {
+    try {
+      db.setLogger(null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("logger == null");
+    }
+  }
+
+  public void testLoggerEnabled() {
+    final List<String> logs = new ArrayList<>();
+    db.setLogger(new SqlBrite.Logger() {
+      @Override public void log(String message) {
+        logs.add(message);
+      }
+    });
+
+    subscription = db.createQuery(TABLE, null, null, null, null, false).subscribe(o);
+    o.assertCursor().isExhausted();
+
+    contentResolver.insert(TABLE, values("key1", "value1"));
+    o.assertCursor().hasRow("key1", "value1").isExhausted();
+    assertThat(logs).isNotEmpty();
+  }
+
+  public void testLoggerDisabled() {
+    final List<String> logs = new ArrayList<>();
+    db.setLoggingEnabled(false);
+    db.setLogger(new SqlBrite.Logger() {
+      @Override public void log(String message) {
+        logs.add(message);
+      }
+    });
+
+    contentResolver.insert(TABLE, values("key1", "value1"));
+    assertThat(logs).isEmpty();
+  }
+
+  public void testCreateQueryObservesInsert() {
+    subscription = db.createQuery(TABLE, null, null, null, null, false).subscribe(o);
+    o.assertCursor().isExhausted();
+
+    contentResolver.insert(TABLE, values("key1", "val1"));
+    o.assertCursor().hasRow("key1", "val1").isExhausted();
+  }
+
+  public void testCreateQueryObservesUpdate() {
+    contentResolver.insert(TABLE, values("key1", "val1"));
+    subscription = db.createQuery(TABLE, null, null, null, null, false).subscribe(o);
+    o.assertCursor().hasRow("key1", "val1").isExhausted();
+
+    contentResolver.update(TABLE, values("key1", "val2"), null, null);
+    o.assertCursor().hasRow("key1", "val2").isExhausted();
+  }
+
+  public void testCreateQueryObservesDelete() {
+    contentResolver.insert(TABLE, values("key1", "val1"));
+    subscription = db.createQuery(TABLE, null, null, null, null, false).subscribe(o);
+    o.assertCursor().hasRow("key1", "val1").isExhausted();
+
+    contentResolver.delete(TABLE, null, null);
+    o.assertCursor().isExhausted();
+  }
+
+  public void testUnsubscribeDoesNotTrigger() {
+    final List<String> logs = new ArrayList<>();
+    db.setLogger(new SqlBrite.Logger() {
+      @Override public void log(String message) {
+        logs.add(message);
+      }
+    });
+
+    subscription = db.createQuery(TABLE, null, null, null, null, false).subscribe(o);
+    o.assertCursor().isExhausted();
+    subscription.unsubscribe();
+
+    contentResolver.insert(TABLE, values("key1", "val1"));
+    o.assertNoMoreEvents();
+    assertThat(logs).isEmpty();
+  }
+
+  private ContentValues values(String key, String value) {
+    ContentValues result = new ContentValues();
+    result.put(KEY, key);
+    result.put(VALUE, value);
+    return result;
+  }
+
+  public static final class TestContentProvider extends MockContentProvider {
+    private final Map<String, String> storage = new LinkedHashMap<>();
+
+    private ContentResolver contentResolver;
+
+    void init(ContentResolver contentResolver) {
+      this.contentResolver = contentResolver;
+    }
+
+    @Override public Uri insert(Uri uri, ContentValues values) {
+      storage.put(values.getAsString(KEY), values.getAsString(VALUE));
+      contentResolver.notifyChange(uri, null);
+      return Uri.parse(AUTHORITY + "/" + values.getAsString(KEY));
+    }
+
+    @Override public int update(Uri uri, ContentValues values, String selection,
+        String[] selectionArgs) {
+      for (String key : storage.keySet()) {
+        storage.put(key, values.getAsString(VALUE));
+      }
+      contentResolver.notifyChange(uri, null);
+      return storage.size();
+    }
+
+    @Override public int delete(Uri uri, String selection, String[] selectionArgs) {
+      int result = storage.size();
+      storage.clear();
+      contentResolver.notifyChange(uri, null);
+      return result;
+    }
+
+    @Override public Cursor query(Uri uri, String[] projection, String selection,
+        String[] selectionArgs, String sortOrder) {
+      MatrixCursor result = new MatrixCursor(new String[] { KEY, VALUE });
+      for (Map.Entry<String, String> entry : storage.entrySet()) {
+        result.addRow(new Object[] { entry.getKey(), entry.getValue() });
+      }
+      return result;
+    }
+  }
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/SqlBriteContentProvider.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/SqlBriteContentProvider.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqlbrite;
+
+import android.content.ContentResolver;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import java.util.Arrays;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+import static com.squareup.sqlbrite.SqlBrite.Logger;
+import static com.squareup.sqlbrite.SqlBrite.Query;
+
+/**
+ * A lightweight wrapper around {@link ContentResolver} which allows for continuously observing
+ * the result of a query.
+ */
+public final class SqlBriteContentProvider {
+  public static SqlBriteContentProvider create(@NonNull ContentResolver contentResolver) {
+    return new SqlBriteContentProvider(contentResolver);
+  }
+
+  private final Handler contentObserverHandler = new Handler(Looper.getMainLooper());
+  private final ContentResolver contentResolver;
+
+  // Not volatile because we don't care if threads don't immediately see changes to this value.
+  private boolean logging;
+  private volatile Logger logger;
+
+  private SqlBriteContentProvider(ContentResolver contentResolver) {
+    this.contentResolver = contentResolver;
+  }
+
+  /**
+   * Control whether debug logging is enabled.
+   * <p>
+   * By default this method will log verbose message to {@linkplain Log Android's log}. Use a
+   * custom logger by calling {@link #setLogger}.
+   */
+  public void setLoggingEnabled(boolean enabled) {
+    if (enabled && logger == null) {
+      logger = new Logger() {
+        @Override public void log(String message) {
+          Log.v("SqlBrite", message);
+        }
+      };
+    }
+    logging = enabled;
+  }
+
+  /**
+   * Specify a custom logger for debug messages when {@linkplain #setLoggingEnabled(boolean)
+   * logging is enabled}.
+   */
+  public void setLogger(Logger logger) {
+    if (logger == null) throw new NullPointerException("logger == null");
+    this.logger = logger;
+  }
+
+  /**
+   * Create an observable which will notify subscribers with a {@linkplain Query query} for
+   * execution. Subscribers are responsible for <b>always</b> closing {@link Cursor} instance
+   * returned from the {@link Query}.
+   * <p>
+   * Subscribers will receive an immediate notification for initial data as well as subsequent
+   * notifications for when the supplied {@code uri}'s data changes. Unsubscribe when you no longer
+   * want updates to a query.
+   * <p>
+   * <b>Warning:</b> this method does not perform the query! Only by subscribing to the returned
+   * {@link Observable} will the operation occur.
+   *
+   * @see ContentResolver#query(Uri, String[], String, String[], String)
+   * @see ContentResolver#registerContentObserver(Uri, boolean, ContentObserver)
+   */
+  public Observable<Query> createQuery(@NonNull final Uri uri, @Nullable final String[] projection,
+      @Nullable final String selection, @Nullable final String[] selectionArgs, @Nullable
+      final String sortOrder, final boolean notifyForDescendents) {
+    final Query query = new Query() {
+      @Override public Cursor run() {
+        return contentResolver.query(uri, projection, selection, selectionArgs, sortOrder);
+      }
+    };
+    return Observable.create(new Observable.OnSubscribe<Query>() {
+      @Override public void call(final Subscriber<? super Query> subscriber) {
+        final ContentObserver observer = new ContentObserver(contentObserverHandler) {
+          @Override public void onChange(boolean selfChange) {
+            if (logging) {
+              log("QUERY\n  uri: %s\n  projection: %s\n  selection: %s\n  selectionArgs: %s\n  "
+                      + "sortOrder: %s\n  notifyForDescendents: %s", uri,
+                  Arrays.toString(projection), selection, Arrays.toString(selectionArgs), sortOrder,
+                  notifyForDescendents);
+            }
+            subscriber.onNext(query);
+          }
+        };
+        contentResolver.registerContentObserver(uri, notifyForDescendents, observer);
+        subscriber.add(Subscriptions.create(new Action0() {
+          @Override public void call() {
+            contentResolver.unregisterContentObserver(observer);
+          }
+        }));
+      }
+    }).startWith(query);
+  }
+
+  private void log(String message, Object... args) {
+    if (args.length > 0) message = String.format(message, args);
+    logger.log(message);
+  }
+}


### PR DESCRIPTION
 - Expose the same Logger/Query api that SqlBrite does
 - Wrap ContentResolver database operations

Closes #13 