### PR TITLE
Add Query to the cause of exception in QueryObservable

### DIFF
--- a/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/QueryObservableTest.java
+++ b/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/QueryObservableTest.java
@@ -1,0 +1,64 @@
+package com.squareup.sqlbrite;
+
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.squareup.sqlbrite.SqlBrite.Query;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import rx.Observable;
+import rx.functions.Func1;
+import rx.observers.TestSubscriber;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public final class QueryObservableTest {
+
+  @Test public void mapToListThrowsFromQueryRun() {
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
+
+    new QueryObservable(Observable.<Query>just(new Query() {
+      @Override public Cursor run() {
+        throw new IllegalStateException("test exception");
+      }
+    })).mapToList(new Func1<Cursor, Object>() {
+      @Override public Object call(Cursor cursor) {
+        throw new AssertionError("Must not be called");
+      }
+    }).subscribe(testSubscriber);
+
+    testSubscriber.awaitTerminalEvent();
+    testSubscriber.assertNoValues();
+    assertThat(testSubscriber.getOnErrorEvents()).hasSize(1);
+
+    IllegalStateException expected = (IllegalStateException) testSubscriber.getOnErrorEvents().get(0);
+    assertThat(expected).hasMessage("test exception");
+  }
+
+  @Test public void mapToListThrowsFromMapFunction() {
+    TestSubscriber<Object> testSubscriber = new TestSubscriber<>();
+
+    new QueryObservable(Observable.<Query>just(new Query() {
+      @Override public Cursor run() {
+        MatrixCursor cursor = new MatrixCursor(new String[]{"col1"});
+        cursor.addRow(new Object[]{"value1"});
+        return cursor;
+      }
+    })).mapToList(new Func1<Cursor, Object>() {
+      @Override public Object call(Cursor cursor) {
+        throw new IllegalStateException("test exception");
+      }
+    }).subscribe(testSubscriber);
+
+    testSubscriber.awaitTerminalEvent();
+    testSubscriber.assertNoValues();
+    assertThat(testSubscriber.getOnErrorEvents()).hasSize(1);
+
+    IllegalStateException expected = (IllegalStateException) testSubscriber.getOnErrorEvents().get(0);
+    assertThat(expected).hasMessage("test exception");
+  }
+}


### PR DESCRIPTION
Now `Query.toString()` will be part of the exception stack trace for `QueryObservable.mapToList()`.

Plus 2 little unit tests to assert that `QueryObservable` respects the `Observable` contract at least for errors.