### PR TITLE
Update Query arguments at Query.run()

### DIFF
--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteContentResolver.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteContentResolver.java
@@ -76,8 +76,10 @@ public final class BriteContentResolver {
       @Nullable final String selection, @Nullable final String[] selectionArgs, @Nullable
       final String sortOrder, final boolean notifyForDescendents) {
     final Query query = new Query() {
-      @Override public Cursor run() {
-        return contentResolver.query(uri, projection, selection, selectionArgs, sortOrder);
+      @Override public Cursor run(String... updatedArgs) {
+        String[] effectiveArgs = selectionArgs;
+        if(updatedArgs.length != 0) effectiveArgs = updatedArgs;
+        return contentResolver.query(uri, projection, selection, effectiveArgs, sortOrder);
       }
     };
     OnSubscribe<Query> subscribe = new OnSubscribe<Query>() {

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteDatabase.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteDatabase.java
@@ -275,11 +275,13 @@ public final class BriteDatabase implements Closeable {
     }
 
     final Query query = new Query() {
-      @Override public Cursor run() {
+      @Override public Cursor run(final String... updatedArgs) {
         if (transactions.get() != null) {
           throw new IllegalStateException("Cannot execute observable query in a transaction.");
         }
-        return getReadableDatabase().rawQuery(sql, args);
+          String[] effectiveArgs = args;
+          if(updatedArgs.length != 0) effectiveArgs = updatedArgs;
+        return getReadableDatabase().rawQuery(sql, effectiveArgs);
       }
 
       @Override public String toString() {

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/SqlBrite.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/SqlBrite.java
@@ -75,7 +75,7 @@ public final class SqlBrite {
     /** Execute the query on the underlying database and return the resulting cursor. */
     @CheckResult @WorkerThread
     // TODO Implementations might return null, which is gross. Throw?
-    public abstract Cursor run();
+    public abstract Cursor run(final String... updatedArgs);
 
     /**
      * Execute the query on the underlying database and return an Observable of each row mapped to
@@ -98,10 +98,10 @@ public final class SqlBrite {
      * a query and should be preferred, where possible.
      */
     @CheckResult @NonNull
-    public final <T> Observable<T> asRows(final Func1<Cursor, T> mapper) {
+    public final <T> Observable<T> asRows(final Func1<Cursor, T> mapper, final String... updatedArgs) {
       return Observable.create(new Observable.OnSubscribe<T>() {
         @Override public void call(Subscriber<? super T> subscriber) {
-          Cursor cursor = run();
+          Cursor cursor = run(updatedArgs);
           try {
             while (cursor.moveToNext() && !subscriber.isUnsubscribed()) {
               subscriber.onNext(mapper.call(cursor));


### PR DESCRIPTION
Updating arguments within Query.run() can increase code lisibility, as we can write this:

```java
public Cursor getSomething(Observable<String> arg1, Observable<String> arg2){
   Observable<Query> query = createQuery();
   Observable.combineLatest(arg1, arg2, query, new Func3<String, String, Query, Cursor>(){
      @Override public Cursor call(String arg1, String arg2, Query query){
         return query.run(arg1, arg2);
      }
   });
}
```

Instead of:

```java
public Cursor getSomething(Observable<String> arg1, Observable<String> arg2){
   Observable.combineLatest(arg1, arg2, new Func2<String, String, String>(){
      @Override public String call(String arg1, String arg2){
         return buildSqlStringForQueryX(arg1, arg2);
      }
   }).flatMap(new Func1<String, Observable<Query>>(){
      @Override public Observable<Query> call(String query){
         return db.createQuery(TABLE, query);
      }
   }
}
```

I might be wrong but this is how I am currently using SqlBrite to run `Queries` with arguments.
There might be better ways of implementing this, like adding a seperate method like `runWithArgs(String... args)`.

This is just an idea, not an actual pull request.
My code might even not be working.

I'm not confortable contributing to projects that are not mine, maybe this is inappropriate...