### PR TITLE
Provide convenience operators for mapping to a single item.

### DIFF
--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/QueryToListOperator.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/QueryToListOperator.java
@@ -1,0 +1,55 @@
+package com.squareup.sqlbrite;
+
+import android.database.Cursor;
+import java.util.ArrayList;
+import java.util.List;
+import rx.Observable;
+import rx.Subscriber;
+import rx.exceptions.Exceptions;
+import rx.exceptions.OnErrorThrowable;
+import rx.functions.Func1;
+
+final class QueryToListOperator<T> implements Observable.Operator<List<T>, SqlBrite.Query> {
+  private final Func1<Cursor, T> mapper;
+
+  QueryToListOperator(Func1<Cursor, T> mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Subscriber<? super SqlBrite.Query> call(final Subscriber<? super List<T>> subscriber) {
+    return new Subscriber<SqlBrite.Query>(subscriber) {
+      @Override public void onNext(SqlBrite.Query query) {
+        try {
+          Cursor cursor = query.run();
+          List<T> items = new ArrayList<>(cursor.getCount());
+          try {
+            for (int i = 1; cursor.moveToNext() && !subscriber.isUnsubscribed(); i++) {
+              T item = mapper.call(cursor);
+              if (item == null) {
+                throw new NullPointerException("Mapper returned null for row " + i);
+              }
+              items.add(item);
+            }
+          } finally {
+            cursor.close();
+          }
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onNext(items);
+          }
+        } catch (Throwable e) {
+          Exceptions.throwIfFatal(e);
+          onError(OnErrorThrowable.addValueAsLastCause(e, query.toString()));
+        }
+      }
+
+      @Override public void onCompleted() {
+        subscriber.onCompleted();
+      }
+
+      @Override public void onError(Throwable e) {
+        subscriber.onError(e);
+      }
+    };
+  }
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/QueryToOneOperator.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/QueryToOneOperator.java
@@ -1,0 +1,56 @@
+package com.squareup.sqlbrite;
+
+import android.database.Cursor;
+import rx.Observable;
+import rx.Subscriber;
+import rx.exceptions.Exceptions;
+import rx.exceptions.OnErrorThrowable;
+import rx.functions.Func1;
+
+final class QueryToOneOperator<T> implements Observable.Operator<T, SqlBrite.Query> {
+  private final Func1<Cursor, T> mapper;
+  private final boolean emitNull;
+
+  QueryToOneOperator(Func1<Cursor, T> mapper, boolean emitNull) {
+    this.mapper = mapper;
+    this.emitNull = emitNull;
+  }
+
+  @Override public Subscriber<? super SqlBrite.Query> call(final Subscriber<? super T> subscriber) {
+    return new Subscriber<SqlBrite.Query>(subscriber) {
+      @Override public void onNext(SqlBrite.Query query) {
+        try {
+          T item = null;
+          Cursor cursor = query.run();
+          try {
+            if (cursor.moveToNext()) {
+              item = mapper.call(cursor);
+              if (item == null) {
+                throw new NullPointerException("Mapper returned null for row 1");
+              }
+              if (cursor.moveToNext()) {
+                throw new IllegalStateException("Cursor returned more than 1 row");
+              }
+            }
+          } finally {
+            cursor.close();
+          }
+          if (!subscriber.isUnsubscribed() && (item != null || emitNull)) {
+            subscriber.onNext(item);
+          }
+        } catch (Throwable e) {
+          Exceptions.throwIfFatal(e);
+          onError(OnErrorThrowable.addValueAsLastCause(e, query.toString()));
+        }
+      }
+
+      @Override public void onCompleted() {
+        subscriber.onCompleted();
+      }
+
+      @Override public void onError(Throwable e) {
+        subscriber.onError(e);
+      }
+    };
+  }
+}


### PR DESCRIPTION
Queries returning single items is very common. It's not too terrible to do this yourself with Query#asRows, but we can provide something even more readable at little inconvenience.

cc @danh32