### PR TITLE
Remove unnecessary volatile keyword being used

### DIFF
--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/BackpressureBufferLastOperator.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/BackpressureBufferLastOperator.java
@@ -43,8 +43,8 @@ final class BackpressureBufferLastOperator<T> implements Operator<T, T> {
 
     private final Subscriber<? super T> child;
 
-    private volatile Object last = NONE; // Guarded by 'this'.
-    private volatile long requested; // Guarded by 'this'. Starts at zero.
+    private Object last = NONE; // Guarded by 'this'.
+    private long requested; // Guarded by 'this'. Starts at zero.
 
     final Producer producer = new Producer() {
       @Override public void request(long n) {


### PR DESCRIPTION
The fields are already "Guarded by 'this'".