### PR TITLE
Expose static mapping operators on Query.

### DIFF
--- a/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/QueryTest.java
+++ b/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/QueryTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqlbrite;
+
+import android.database.Cursor;
+import android.support.test.InstrumentationRegistry;
+import com.squareup.sqlbrite.SqlBrite.Query;
+import com.squareup.sqlbrite.TestDb.Employee;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import rx.functions.Func1;
+import rx.observables.BlockingObservable;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.squareup.sqlbrite.TestDb.SELECT_EMPLOYEES;
+import static com.squareup.sqlbrite.TestDb.TABLE_EMPLOYEE;
+
+public final class QueryTest {
+  private BriteDatabase db;
+
+  @Before public void setUp() {
+    SqlBrite sqlBrite = SqlBrite.create();
+    TestDb helper = new TestDb(InstrumentationRegistry.getContext());
+    db = sqlBrite.wrapDatabaseHelper(helper);
+  }
+
+  @Test public void mapToOne() {
+    Employee employees = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 1")
+        .lift(Query.mapToOne(Employee.MAPPER))
+        .toBlocking()
+        .first();
+    assertThat(employees).isEqualTo(new Employee("alice", "Alice Allison"));
+  }
+
+  @Test public void mapToOneThrowsOnMapperNull() {
+    BlockingObservable<Employee> employees =
+        db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES) //
+            .lift(Query.mapToOne(new Func1<Cursor, Employee>() {
+              @Override public Employee call(Cursor cursor) {
+                return null;
+              }
+            })) //
+            .toBlocking();
+    try {
+      employees.first();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("Mapper returned null for row 1");
+      assertThat(e.getCause()).hasMessage(
+          "OnError while emitting onNext value: SELECT username, name FROM employee");
+    }
+  }
+
+  @Test public void mapToOneNoOpOnNoRows() {
+    List<Employee> employees = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " WHERE 1=2")
+        .take(1)
+        .lift(Query.mapToOne(Employee.MAPPER))
+        .toList()
+        .toBlocking()
+        .first();
+    assertThat(employees).isEmpty();
+  }
+
+  @Test public void mapToOneThrowsOnMultipleRows() {
+    BlockingObservable<Employee> employees =
+        db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 2") //
+            .lift(Query.mapToOne(Employee.MAPPER)) //
+            .toBlocking();
+    try {
+      employees.first();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Cursor returned more than 1 row");
+      assertThat(e.getCause()).hasMessage(
+          "OnError while emitting onNext value: SELECT username, name FROM employee LIMIT 2");
+    }
+  }
+
+  @Test public void mapToOneOrDefault() {
+    Employee employees = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 1")
+        .lift(Query.mapToOneOrDefault(Employee.MAPPER, null))
+        .toBlocking()
+        .first();
+    assertThat(employees).isEqualTo(new Employee("alice", "Alice Allison"));
+  }
+
+  @Test public void mapToOneOrDefaultReturnsDefaultWhenNoRows() {
+    Employee defaultEmployee = new Employee("bob", "Bob Bobberson");
+    Employee employees = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " WHERE 1=2")
+        .lift(Query.mapToOneOrDefault(Employee.MAPPER, defaultEmployee))
+        .toBlocking()
+        .first();
+    assertThat(employees).isSameAs(defaultEmployee);
+  }
+
+  @Test public void mapToOneOrDefaultAllowsNullDefault() {
+    Employee employees = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " WHERE 1=2")
+        .lift(Query.mapToOneOrDefault(Employee.MAPPER, null))
+        .toBlocking()
+        .first();
+    assertThat(employees).isNull();
+  }
+
+  @Test public void mapToOneOrDefaultThrowsOnMapperNull() {
+    BlockingObservable<Employee> employees =
+        db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES) //
+            .lift(Query.mapToOneOrDefault(new Func1<Cursor, Employee>() {
+              @Override public Employee call(Cursor cursor) {
+                return null;
+              }
+            }, null)) //
+            .toBlocking();
+    try {
+      employees.first();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("Mapper returned null for row 1");
+      assertThat(e.getCause()).hasMessage(
+          "OnError while emitting onNext value: SELECT username, name FROM employee");
+    }
+  }
+
+  @Test public void mapToOneOrDefaultThrowsOnMultipleRows() {
+    BlockingObservable<Employee> employees =
+        db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 2") //
+            .lift(Query.mapToOneOrDefault(Employee.MAPPER, null)) //
+            .toBlocking();
+    try {
+      employees.first();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Cursor returned more than 1 row");
+      assertThat(e.getCause()).hasMessage(
+          "OnError while emitting onNext value: SELECT username, name FROM employee LIMIT 2");
+    }
+  }
+
+  @Test public void mapToList() {
+    List<Employee> employees = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES)
+        .lift(Query.mapToList(Employee.MAPPER))
+        .toBlocking()
+        .first();
+    assertThat(employees).containsExactly( //
+        new Employee("alice", "Alice Allison"), //
+        new Employee("bob", "Bob Bobberson"), //
+        new Employee("eve", "Eve Evenson"));
+  }
+
+  @Test public void mapToListEmptyWhenNoRows() {
+    List<Employee> employees = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " WHERE 1=2")
+        .lift(Query.mapToList(Employee.MAPPER))
+        .toBlocking()
+        .first();
+    assertThat(employees).isEmpty();
+  }
+
+  @Test public void mapToListThrowsOnMapperNull() {
+    BlockingObservable<List<Employee>> employees =
+        db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES) //
+            .lift(Query.mapToList(new Func1<Cursor, Employee>() {
+              private int count;
+
+              @Override public Employee call(Cursor cursor) {
+                return count++ == 2 ? null : Employee.MAPPER.call(cursor);
+              }
+            })) //
+            .toBlocking();
+    try {
+      employees.first();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("Mapper returned null for row 3");
+      assertThat(e.getCause()).hasMessage(
+          "OnError while emitting onNext value: SELECT username, name FROM employee");
+    }
+  }
+}

--- a/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/TestDb.java
+++ b/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/TestDb.java
@@ -21,11 +21,31 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.support.annotation.NonNull;
+import java.util.Arrays;
+import java.util.Collection;
 import rx.functions.Func1;
+
+import static com.squareup.sqlbrite.TestDb.EmployeeTable.ID;
+import static com.squareup.sqlbrite.TestDb.EmployeeTable.NAME;
+import static com.squareup.sqlbrite.TestDb.EmployeeTable.USERNAME;
+import static com.squareup.sqlbrite.TestDb.ManagerTable.EMPLOYEE_ID;
+import static com.squareup.sqlbrite.TestDb.ManagerTable.MANAGER_ID;
 
 final class TestDb extends SQLiteOpenHelper {
   static final String TABLE_EMPLOYEE = "employee";
   static final String TABLE_MANAGER = "manager";
+
+  static final String SELECT_EMPLOYEES =
+      "SELECT " + USERNAME + ", " + NAME + " FROM " + TABLE_EMPLOYEE;
+  static final String SELECT_MANAGER_LIST = ""
+      + "SELECT e." + NAME + ", m." + NAME + " "
+      + "FROM " + TABLE_MANAGER + " AS manager "
+      + "JOIN " + TABLE_EMPLOYEE + " AS e "
+      + "ON manager." + EMPLOYEE_ID + " = e." + ID + " "
+      + "JOIN " + TABLE_EMPLOYEE + " as m "
+      + "ON manager." + MANAGER_ID + " = m." + ID;
+  static final Collection<String> BOTH_TABLES =
+      Arrays.asList(TABLE_EMPLOYEE, TABLE_MANAGER);
 
   interface EmployeeTable {
     String ID = "_id";

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/QueryObservable.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/QueryObservable.java
@@ -31,12 +31,16 @@ public final class QueryObservable extends Observable<Query> {
    * <pre>{@code
    * flatMap(q -> q.asRows(mapper).take(1))
    * }</pre>
+   * and a convenience operator for:
+   * <pre>{@code
+   * lift(Query.mapToOne(mapper))
+   * }</pre>
    *
    * @param mapper Maps the current {@link Cursor} row to {@code T}. May not return null.
    */
   @CheckResult @NonNull
-  public final <T> Observable<T> mapToOne(@NonNull final Func1<Cursor, T> mapper) {
-    return lift(new QueryToOneOperator<>(mapper, false, null));
+  public final <T> Observable<T> mapToOne(@NonNull Func1<Cursor, T> mapper) {
+    return lift(Query.mapToOne(mapper));
   }
 
   /**
@@ -51,14 +55,18 @@ public final class QueryObservable extends Observable<Query> {
    * <pre>{@code
    * flatMap(q -> q.asRows(mapper).take(1).defaultIfEmpty(defaultValue))
    * }</pre>
+   * and a convenience operator for:
+   * <pre>{@code
+   * lift(Query.mapToOneOrDefault(mapper, defaultValue))
+   * }</pre>
    *
    * @param mapper Maps the current {@link Cursor} row to {@code T}. May not return null.
    * @param defaultValue Value returned if result set is empty
    */
   @CheckResult @NonNull
-  public final <T> Observable<T> mapToOneOrDefault(@NonNull final Func1<Cursor, T> mapper,
+  public final <T> Observable<T> mapToOneOrDefault(@NonNull Func1<Cursor, T> mapper,
       T defaultValue) {
-    return lift(new QueryToOneOperator<>(mapper, true, defaultValue));
+    return lift(Query.mapToOneOrDefault(mapper, defaultValue));
   }
 
   /**
@@ -73,12 +81,17 @@ public final class QueryObservable extends Observable<Query> {
    * <pre>{@code
    * flatMap(q -> q.asRows(mapper).toList())
    * }</pre>
+   * and a convenience operator for:
+   * <pre>{@code
+   * lift(Query.mapToList(mapper))
+   * }</pre>
+   * <p>
    * Consider using {@link Query#asRows} if you need to limit or filter in memory.
    *
    * @param mapper Maps the current {@link Cursor} row to {@code T}. May not return null.
    */
   @CheckResult @NonNull
-  public final <T> Observable<List<T>> mapToList(@NonNull final Func1<Cursor, T> mapper) {
-    return lift(new QueryToListOperator<>(mapper));
+  public final <T> Observable<List<T>> mapToList(@NonNull Func1<Cursor, T> mapper) {
+    return lift(Query.mapToList(mapper));
   }
 }


### PR DESCRIPTION
These match the convenience methods on QueryObservable, but are available for use later in the stream (e.g., after a take() operator) via lift().

Closes #69.