### PR TITLE
Take an emission scheduler when creating wrapper types.

### DIFF
--- a/sample/src/main/java/com/example/sqlbrite/todo/db/DbModule.java
+++ b/sample/src/main/java/com/example/sqlbrite/todo/db/DbModule.java
@@ -22,6 +22,7 @@ import com.squareup.sqlbrite.SqlBrite;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Singleton;
+import rx.schedulers.Schedulers;
 import timber.log.Timber;
 
 @Module(complete = false, library = true)
@@ -39,7 +40,7 @@ public final class DbModule {
   }
 
   @Provides @Singleton BriteDatabase provideDatabase(SqlBrite sqlBrite, SQLiteOpenHelper helper) {
-    BriteDatabase db = sqlBrite.wrapDatabaseHelper(helper);
+    BriteDatabase db = sqlBrite.wrapDatabaseHelper(helper, Schedulers.io());
     db.setLoggingEnabled(true);
     return db;
   }

--- a/sample/src/main/java/com/example/sqlbrite/todo/ui/ItemsFragment.java
+++ b/sample/src/main/java/com/example/sqlbrite/todo/ui/ItemsFragment.java
@@ -187,7 +187,6 @@ public final class ItemsFragment extends Fragment {
             return listName + " (" + itemCount + ")";
           }
         })
-            .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(new Action1<String>() {
               @Override public void call(String title) {
@@ -197,7 +196,6 @@ public final class ItemsFragment extends Fragment {
 
     subscriptions.add(db.createQuery(TodoItem.TABLE, LIST_QUERY, listId)
         .mapToList(TodoItem.MAPPER)
-        .subscribeOn(Schedulers.io())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(adapter));
   }

--- a/sample/src/main/java/com/example/sqlbrite/todo/ui/ListsFragment.java
+++ b/sample/src/main/java/com/example/sqlbrite/todo/ui/ListsFragment.java
@@ -36,7 +36,6 @@ import com.squareup.sqlbrite.BriteDatabase;
 import javax.inject.Inject;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
-import rx.schedulers.Schedulers;
 
 import static android.support.v4.view.MenuItemCompat.SHOW_AS_ACTION_IF_ROOM;
 import static android.support.v4.view.MenuItemCompat.SHOW_AS_ACTION_WITH_TEXT;
@@ -110,7 +109,6 @@ public final class ListsFragment extends Fragment {
 
     subscription = db.createQuery(ListsItem.TABLES, ListsItem.QUERY)
         .mapToList(ListsItem.MAPPER)
-        .subscribeOn(Schedulers.io())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(adapter);
   }

--- a/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/QueryTest.java
+++ b/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/QueryTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import rx.functions.Func1;
 import rx.observables.BlockingObservable;
+import rx.schedulers.Schedulers;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.sqlbrite.TestDb.SELECT_EMPLOYEES;
@@ -35,7 +36,7 @@ public final class QueryTest {
   @Before public void setUp() {
     SqlBrite sqlBrite = SqlBrite.create();
     TestDb helper = new TestDb(InstrumentationRegistry.getContext());
-    db = sqlBrite.wrapDatabaseHelper(helper);
+    db = sqlBrite.wrapDatabaseHelper(helper, Schedulers.immediate());
   }
 
   @Test public void mapToOne() {

--- a/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/TestScheduler.java
+++ b/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/TestScheduler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqlbrite;
+
+import java.util.concurrent.TimeUnit;
+import rx.Scheduler;
+import rx.Subscription;
+import rx.functions.Action0;
+
+final class TestScheduler extends Scheduler {
+  private final rx.schedulers.TestScheduler delegate = new rx.schedulers.TestScheduler();
+  private boolean runTasksImmediately = true;
+
+  public void runTasksImmediately(boolean runTasksImmediately) {
+    this.runTasksImmediately = runTasksImmediately;
+  }
+
+  public void triggerActions() {
+    delegate.triggerActions();
+  }
+
+  @Override public Worker createWorker() {
+    return new TestWorker();
+  }
+
+  class TestWorker extends Worker {
+    private final Worker delegateWorker = delegate.createWorker();
+
+    @Override public Subscription schedule(Action0 action) {
+      Subscription subscription = delegateWorker.schedule(action);
+      if (runTasksImmediately) {
+        triggerActions();
+      }
+      return subscription;
+    }
+
+    @Override public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
+      Subscription subscription = delegateWorker.schedule(action, delayTime, unit);
+      if (runTasksImmediately) {
+        triggerActions();
+      }
+      return subscription;
+    }
+
+    @Override public void unsubscribe() {
+      delegateWorker.unsubscribe();
+    }
+
+    @Override public boolean isUnsubscribed() {
+      return delegateWorker.isUnsubscribed();
+    }
+  }
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteContentResolver.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteContentResolver.java
@@ -27,6 +27,7 @@ import android.support.annotation.Nullable;
 import java.util.Arrays;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
+import rx.Scheduler;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
@@ -45,12 +46,14 @@ public final class BriteContentResolver {
 
   final ContentResolver contentResolver;
   private final Logger logger;
+  private final Scheduler scheduler;
 
   volatile boolean logging;
 
-  BriteContentResolver(@NonNull ContentResolver contentResolver, @NonNull Logger logger) {
+  BriteContentResolver(ContentResolver contentResolver, Logger logger, Scheduler scheduler) {
     this.contentResolver = contentResolver;
     this.logger = logger;
+    this.scheduler = scheduler;
   }
 
   /** Control whether debug logging is enabled. */
@@ -66,6 +69,11 @@ public final class BriteContentResolver {
    * Subscribers will receive an immediate notification for initial data as well as subsequent
    * notifications for when the supplied {@code uri}'s data changes. Unsubscribe when you no longer
    * want updates to a query.
+   * <p>
+   * Since content resolver triggers are inherently asynchronous, items emitted from the returned
+   * observable use the {@link Scheduler} supplied to {@link SqlBrite#wrapContentProvider}. For
+   * consistency, the immediate notification sent on subscribe also uses this scheduler. As such,
+   * calling {@link Observable#subscribeOn subscribeOn} on the returned observable has no effect.
    * <p>
    * Note: To skip the immediate notification and only receive subsequent notifications when data
    * has changed call {@code skip(1)} on the returned observable.
@@ -113,6 +121,7 @@ public final class BriteContentResolver {
     };
     Observable<Query> queryObservable = Observable.create(subscribe) //
         .startWith(query) //
+        .observeOn(scheduler) //
         .onBackpressureLatest();
     return new QueryObservable(queryObservable);
   }

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/SqlBrite.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/SqlBrite.java
@@ -24,6 +24,7 @@ import android.util.Log;
 import java.util.List;
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.Scheduler;
 import rx.Subscriber;
 import rx.functions.Func1;
 
@@ -59,16 +60,24 @@ public final class SqlBrite {
    * interacting with the underlying {@link SQLiteOpenHelper} and it is required for automatic
    * notifications of table changes to work. See {@linkplain BriteDatabase#createQuery the
    * <code>query</code> method} for more information on that behavior.
+   *
+   * @param scheduler The {@link Scheduler} on which items from {@link BriteDatabase#createQuery}
+   * will be emitted.
    */
-  @CheckResult @NonNull
-  public BriteDatabase wrapDatabaseHelper(@NonNull SQLiteOpenHelper helper) {
-    return new BriteDatabase(helper, logger);
+  @CheckResult @NonNull public BriteDatabase wrapDatabaseHelper(@NonNull SQLiteOpenHelper helper,
+      @NonNull Scheduler scheduler) {
+    return new BriteDatabase(helper, logger, scheduler);
   }
 
-  /** Wrap a {@link ContentResolver} for observable queries. */
-  @CheckResult @NonNull
-  public BriteContentResolver wrapContentProvider(@NonNull ContentResolver contentResolver) {
-    return new BriteContentResolver(contentResolver, logger);
+  /**
+   * Wrap a {@link ContentResolver} for observable queries.
+   *
+   * @param scheduler The {@link Scheduler} on which items from
+   * {@link BriteContentResolver#createQuery} will be emitted.
+   */
+  @CheckResult @NonNull public BriteContentResolver wrapContentProvider(
+      @NonNull ContentResolver contentResolver, @NonNull Scheduler scheduler) {
+    return new BriteContentResolver(contentResolver, logger, scheduler);
   }
 
   /** An executable query. */


### PR DESCRIPTION
This has two positive effects:
- Threads which commit transactions no longer wait on downstream-triggered queries to run.
- Initial and triggered notifications now happen on the same scheduler (actually the same worker, too) which was potentially tricky to get correct before.

Closes #84.