### PR TITLE
Add Scheduler argument to BriteContentResolver example

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The `SqlBrite` object can also wrap a `ContentResolver` for observing a query on
 content provider.
 
 ```java
-BriteContentResolver resolver = sqlBrite.wrapContentProvider(contentResolver);
+BriteContentResolver resolver = sqlBrite.wrapContentProvider(contentResolver, Schedulers.io());
 Observable<Query> query = resolver.createQuery(/*...*/);
 ```
 


### PR DESCRIPTION
The BriteContentResolver example is missing the Schedulers argument. Similar to the wrapDatabaseHelper example, I've added Schedulers.io() as an argument.