### PR TITLE
Guard against a slow scheduler with backpressure strategy.

### DIFF
--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteContentResolver.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteContentResolver.java
@@ -120,9 +120,10 @@ public final class BriteContentResolver {
       }
     };
     Observable<Query> queryObservable = Observable.create(subscribe) //
+        .onBackpressureLatest() // Guard against uncontrollable frequency of upstream emissions.
         .startWith(query) //
         .observeOn(scheduler) //
-        .onBackpressureLatest();
+        .onBackpressureLatest(); // Guard against uncontrollable frequency of scheduler executions.
     return new QueryObservable(queryObservable);
   }
 


### PR DESCRIPTION
Schedulers apply backpressure upstream which previously behaved as an unbounded stream. When the scheduler worker couldn't keep up an MBPE was thrown. We already use the 'latest' strategy for slowing 'Query' emissions after the scheduler so we can apply the same thing before it.

This comes with a subtle change in that transactions will now synchronously run every filter Func before continuing. Previously the filters ran on the scheduler and did not block the thread performing the transaction. This means that the more queries that are listening at once, the slower every transaction's completing step will be. I don't expect this to have any meaningful impact since it's very fast and happening on a background thread already.