### PR TITLE
Trigger initial query with less overhead.

### DIFF
--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteContentResolver.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteContentResolver.java
@@ -117,11 +117,12 @@ public final class BriteContentResolver {
             contentResolver.unregisterContentObserver(observer);
           }
         }));
+
+        subscriber.onNext(query); // Trigger initial query.
       }
     };
     Observable<Query> queryObservable = Observable.create(subscribe) //
         .onBackpressureLatest() // Guard against uncontrollable frequency of upstream emissions.
-        .startWith(query) //
         .observeOn(scheduler) //
         .onBackpressureLatest(); // Guard against uncontrollable frequency of scheduler executions.
     return new QueryObservable(queryObservable);


### PR DESCRIPTION
Rather than a bunch of allocations to create and concat two streams (which startWith does) just move the initial emission to our custom observable.