### PR TITLE
Implemented SQLCipher support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ ext {
   truth = 'com.google.truth:truth:0.27'
   findbugsJsr305 = 'com.google.code.findbugs:jsr305:3.0.0'
   findbugsAnnotations = 'com.google.code.findbugs:annotations:3.0.0'
+  sqlCipher = 'net.zetetic:android-database-sqlcipher:3.3.1-2'
 }
 
 configurations {

--- a/sqlbrite/build.gradle
+++ b/sqlbrite/build.gradle
@@ -10,6 +10,7 @@ apply from: rootProject.file('gradle/android-findbugs.gradle')
 dependencies {
   compile rootProject.ext.rxJava
   compile rootProject.ext.supportAnnotations
+  provided rootProject.ext.sqlCipher
 
   androidTestCompile rootProject.ext.supportTestRunner
   androidTestCompile(rootProject.ext.truth) {

--- a/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/BriteDatabaseTest.java
+++ b/sqlbrite/src/androidTest/java/com/squareup/sqlbrite/BriteDatabaseTest.java
@@ -24,6 +24,8 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import com.squareup.sqlbrite.BriteDatabase.Transaction;
 import com.squareup.sqlbrite.TestDb.Employee;
+import com.squareup.sqlbrite.wrapper.android.SQLiteOpenHelperWrapper;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -74,7 +76,7 @@ public final class BriteDatabaseTest {
         logs.add(message);
       }
     };
-    db = new BriteDatabase(helper, logger, scheduler);
+    db = new BriteDatabase(new SQLiteOpenHelperWrapper(helper), logger, scheduler);
   }
 
   @After public void tearDown() {

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteDatabase.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/BriteDatabase.java
@@ -15,16 +15,18 @@
  */
 package com.squareup.sqlbrite;
 
+import com.squareup.sqlbrite.SqlBrite.Query;
+import com.squareup.sqlbrite.wrapper.SQLiteDatabase;
+import com.squareup.sqlbrite.wrapper.SQLiteOpenHelper;
+import com.squareup.sqlbrite.wrapper.SQLiteTransactionListener;
+
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
-import android.database.sqlite.SQLiteTransactionListener;
 import android.support.annotation.CheckResult;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import com.squareup.sqlbrite.SqlBrite.Query;
+
 import java.io.Closeable;
 import java.lang.annotation.Retention;
 import java.util.Arrays;
@@ -32,6 +34,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
 import rx.Observable;
 import rx.Scheduler;
 import rx.functions.Action0;
@@ -99,6 +102,7 @@ public final class BriteDatabase implements Closeable {
   private volatile SQLiteDatabase readableDatabase;
   private volatile SQLiteDatabase writeableDatabase;
   private final Object databaseLock = new Object();
+  private final String password;
 
   private final Scheduler scheduler;
 
@@ -109,6 +113,14 @@ public final class BriteDatabase implements Closeable {
     this.helper = helper;
     this.logger = logger;
     this.scheduler = scheduler;
+    this.password = null;
+  }
+
+  BriteDatabase(SQLiteOpenHelper helper, SqlBrite.Logger logger, Scheduler scheduler, String password) {
+    this.helper = helper;
+    this.logger = logger;
+    this.scheduler = scheduler;
+    this.password = password;
   }
 
   /**
@@ -125,7 +137,7 @@ public final class BriteDatabase implements Closeable {
         db = readableDatabase;
         if (db == null) {
           if (logging) log("Creating readable database");
-          db = readableDatabase = helper.getReadableDatabase();
+          db = readableDatabase = helper.getReadableDatabase(this.password);
         }
       }
     }
@@ -140,7 +152,7 @@ public final class BriteDatabase implements Closeable {
         db = writeableDatabase;
         if (db == null) {
           if (logging) log("Creating writeable database");
-          db = writeableDatabase = helper.getWritableDatabase();
+          db = writeableDatabase = helper.getWritableDatabase(this.password);
         }
       }
     }

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/SqlBrite.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/SqlBrite.java
@@ -15,14 +15,18 @@
  */
 package com.squareup.sqlbrite;
 
+import com.squareup.sqlbrite.wrapper.SQLiteOpenHelper;
+import com.squareup.sqlbrite.wrapper.android.SQLiteOpenHelperWrapper;
+
 import android.content.ContentResolver;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteOpenHelper;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
+
 import java.util.List;
+
 import rx.Observable;
 import rx.Observable.Operator;
 import rx.Scheduler;
@@ -65,9 +69,30 @@ public final class SqlBrite {
    * @param scheduler The {@link Scheduler} on which items from {@link BriteDatabase#createQuery}
    * will be emitted.
    */
-  @CheckResult @NonNull public BriteDatabase wrapDatabaseHelper(@NonNull SQLiteOpenHelper helper,
+  @CheckResult @NonNull public BriteDatabase wrapDatabaseHelper(
+      @NonNull android.database.sqlite.SQLiteOpenHelper helper,
       @NonNull Scheduler scheduler) {
-    return new BriteDatabase(helper, logger, scheduler);
+    return new BriteDatabase(new SQLiteOpenHelperWrapper(helper), logger, scheduler);
+  }
+
+  /**
+   * Wrap a {@link SQLiteOpenHelper} for observable queries using databases encrypted with SqlCipher.
+   * <p>
+   * While not strictly required, instances of this class assume that they will be the only ones
+   * interacting with the underlying {@link SQLiteOpenHelper} and it is required for automatic
+   * notifications of table changes to work. See {@linkplain BriteDatabase#createQuery the
+   * <code>query</code> method} for more information on that behavior.
+   *
+   * @param scheduler The {@link Scheduler} on which items from {@link BriteDatabase#createQuery}
+   * will be emitted.
+   * @param password The password to be used for encryption
+   */
+  @CheckResult @NonNull public BriteDatabase wrapDatabaseHelper(
+      @NonNull net.sqlcipher.database.SQLiteOpenHelper helper,
+      @NonNull Scheduler scheduler, @NonNull String password) {
+    return new BriteDatabase(
+            new com.squareup.sqlbrite.wrapper.sqlcipher.SQLiteOpenHelperWrapper(helper),
+            logger, scheduler, password);
   }
 
   /**

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/SQLiteDatabase.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/SQLiteDatabase.java
@@ -1,0 +1,43 @@
+package com.squareup.sqlbrite.wrapper;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.SQLException;
+
+/**
+ * Wraps methods from {@link android.database.sqlite.SQLiteDatabase} to allow different
+ * implementations.
+ */
+public interface SQLiteDatabase {
+
+  void beginTransactionWithListener(SQLiteTransactionListener transactionListener);
+
+  void setTransactionSuccessful();
+
+  boolean yieldIfContendedSafely();
+
+  boolean yieldIfContendedSafely(long sleepAfterYieldDelay);
+
+  void endTransaction();
+
+  void beginTransaction();
+
+  Cursor rawQuery(String sql, String[] selectionArgs);
+
+  long insert(String table, String nullColumnHack, ContentValues values);
+
+  long insertWithOnConflict(String table, String nullColumnHack,
+      ContentValues initialValues, int conflictAlgorithm);
+
+  int delete(String table, String whereClause, String[] whereArgs);
+
+  int update(String table, ContentValues values, String whereClause, String[] whereArgs);
+
+  int updateWithOnConflict(String table, ContentValues values,
+      String whereClause, String[] whereArgs, int conflictAlgorithm);
+
+  void execSQL(String sql) throws SQLException;
+
+  void execSQL(String sql, Object[] bindArgs) throws SQLException;
+
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/SQLiteOpenHelper.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/SQLiteOpenHelper.java
@@ -1,0 +1,17 @@
+package com.squareup.sqlbrite.wrapper;
+
+import android.support.annotation.Nullable;
+
+/**
+ * Wraps methods from {@link android.database.sqlite.SQLiteOpenHelper} to allow different
+ * implementations.
+ */
+public interface SQLiteOpenHelper {
+
+  SQLiteDatabase getReadableDatabase(@Nullable String password);
+
+  SQLiteDatabase getWritableDatabase(@Nullable String password);
+
+  void close();
+
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/SQLiteTransactionListener.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/SQLiteTransactionListener.java
@@ -1,0 +1,15 @@
+package com.squareup.sqlbrite.wrapper;
+
+/**
+ * Wraps methods from {@link android.database.sqlite.SQLiteTransactionListener} to allow different
+ * implementations.
+ */
+public interface SQLiteTransactionListener {
+
+  void onBegin();
+
+  void onCommit();
+
+  void onRollback();
+
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/android/SQLiteDatabaseWrapper.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/android/SQLiteDatabaseWrapper.java
@@ -1,0 +1,93 @@
+package com.squareup.sqlbrite.wrapper.android;
+
+import com.squareup.sqlbrite.wrapper.SQLiteDatabase;
+import com.squareup.sqlbrite.wrapper.SQLiteTransactionListener;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.SQLException;
+
+public class SQLiteDatabaseWrapper implements SQLiteDatabase {
+
+  private final android.database.sqlite.SQLiteDatabase mAndroidDatabase;
+
+  public SQLiteDatabaseWrapper(android.database.sqlite.SQLiteDatabase androidDatabase) {
+    mAndroidDatabase = androidDatabase;
+  }
+
+  @Override
+  public void beginTransactionWithListener(SQLiteTransactionListener transactionListener) {
+    mAndroidDatabase
+        .beginTransactionWithListener(new SQLiteTransactionListenerWrapper(transactionListener));
+  }
+
+  @Override
+  public void setTransactionSuccessful() {
+    mAndroidDatabase.setTransactionSuccessful();
+  }
+
+  @Override
+  public boolean yieldIfContendedSafely() {
+    return mAndroidDatabase.yieldIfContendedSafely();
+  }
+
+  @Override
+  public boolean yieldIfContendedSafely(long sleepAfterYieldDelay) {
+    return mAndroidDatabase.yieldIfContendedSafely(sleepAfterYieldDelay);
+  }
+
+  @Override
+  public void endTransaction() {
+    mAndroidDatabase.endTransaction();
+  }
+
+  @Override
+  public void beginTransaction() {
+    mAndroidDatabase.beginTransaction();
+  }
+
+  @Override
+  public Cursor rawQuery(String sql, String[] selectionArgs) {
+    return mAndroidDatabase.rawQuery(sql, selectionArgs);
+  }
+
+  @Override
+  public long insert(String table, String nullColumnHack, ContentValues values) {
+    return mAndroidDatabase.insert(table, nullColumnHack, values);
+  }
+
+  @Override
+  public long insertWithOnConflict(String table, String nullColumnHack, ContentValues initialValues,
+      int conflictAlgorithm) {
+    return mAndroidDatabase
+        .insertWithOnConflict(table, nullColumnHack, initialValues, conflictAlgorithm);
+  }
+
+  @Override
+  public int delete(String table, String whereClause, String[] whereArgs) {
+    return mAndroidDatabase.delete(table, whereClause, whereArgs);
+  }
+
+  @Override
+  public int update(String table, ContentValues values, String whereClause, String[] whereArgs) {
+    return mAndroidDatabase.update(table, values, whereClause, whereArgs);
+  }
+
+  @Override
+  public int updateWithOnConflict(String table, ContentValues values, String whereClause,
+      String[] whereArgs,
+      int conflictAlgorithm) {
+    return mAndroidDatabase
+        .updateWithOnConflict(table, values, whereClause, whereArgs, conflictAlgorithm);
+  }
+
+  @Override
+  public void execSQL(String sql) throws SQLException {
+    mAndroidDatabase.execSQL(sql);
+  }
+
+  @Override
+  public void execSQL(String sql, Object[] bindArgs) throws SQLException {
+    mAndroidDatabase.execSQL(sql, bindArgs);
+  }
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/android/SQLiteOpenHelperWrapper.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/android/SQLiteOpenHelperWrapper.java
@@ -1,0 +1,30 @@
+package com.squareup.sqlbrite.wrapper.android;
+
+import com.squareup.sqlbrite.wrapper.SQLiteDatabase;
+import com.squareup.sqlbrite.wrapper.SQLiteOpenHelper;
+
+import android.support.annotation.Nullable;
+
+public class SQLiteOpenHelperWrapper implements SQLiteOpenHelper {
+
+  private final android.database.sqlite.SQLiteOpenHelper mAndroidHelper;
+
+  public SQLiteOpenHelperWrapper(android.database.sqlite.SQLiteOpenHelper androidHelper) {
+    mAndroidHelper = androidHelper;
+  }
+
+  @Override
+  public SQLiteDatabase getReadableDatabase(@Nullable String password) {
+    return new SQLiteDatabaseWrapper(mAndroidHelper.getReadableDatabase());
+  }
+
+  @Override
+  public SQLiteDatabase getWritableDatabase(@Nullable String password) {
+    return new SQLiteDatabaseWrapper(mAndroidHelper.getWritableDatabase());
+  }
+
+  @Override
+  public void close() {
+    mAndroidHelper.close();
+  }
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/android/SQLiteTransactionListenerWrapper.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/android/SQLiteTransactionListenerWrapper.java
@@ -1,0 +1,28 @@
+package com.squareup.sqlbrite.wrapper.android;
+
+import com.squareup.sqlbrite.wrapper.SQLiteTransactionListener;
+
+public class SQLiteTransactionListenerWrapper
+    implements android.database.sqlite.SQLiteTransactionListener {
+
+  private final SQLiteTransactionListener mAndroidListener;
+
+  public SQLiteTransactionListenerWrapper(SQLiteTransactionListener androidListener) {
+    mAndroidListener = androidListener;
+  }
+
+  @Override
+  public void onBegin() {
+    mAndroidListener.onBegin();
+  }
+
+  @Override
+  public void onCommit() {
+    mAndroidListener.onCommit();
+  }
+
+  @Override
+  public void onRollback() {
+    mAndroidListener.onRollback();
+  }
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/sqlcipher/SQLiteDatabaseWrapper.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/sqlcipher/SQLiteDatabaseWrapper.java
@@ -1,0 +1,93 @@
+package com.squareup.sqlbrite.wrapper.sqlcipher;
+
+import com.squareup.sqlbrite.wrapper.SQLiteDatabase;
+import com.squareup.sqlbrite.wrapper.SQLiteTransactionListener;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.SQLException;
+
+public class SQLiteDatabaseWrapper implements SQLiteDatabase {
+
+  private final net.sqlcipher.database.SQLiteDatabase mAndroidDatabase;
+
+  public SQLiteDatabaseWrapper(net.sqlcipher.database.SQLiteDatabase androidDatabase) {
+    mAndroidDatabase = androidDatabase;
+  }
+
+  @Override
+  public void beginTransactionWithListener(SQLiteTransactionListener transactionListener) {
+    mAndroidDatabase
+        .beginTransactionWithListener(new SQLiteTransactionListenerWrapper(transactionListener));
+  }
+
+  @Override
+  public void setTransactionSuccessful() {
+    mAndroidDatabase.setTransactionSuccessful();
+  }
+
+  @Override
+  public boolean yieldIfContendedSafely() {
+    return mAndroidDatabase.yieldIfContendedSafely();
+  }
+
+  @Override
+  public boolean yieldIfContendedSafely(long sleepAfterYieldDelay) {
+    return mAndroidDatabase.yieldIfContendedSafely(sleepAfterYieldDelay);
+  }
+
+  @Override
+  public void endTransaction() {
+    mAndroidDatabase.endTransaction();
+  }
+
+  @Override
+  public void beginTransaction() {
+    mAndroidDatabase.beginTransaction();
+  }
+
+  @Override
+  public Cursor rawQuery(String sql, String[] selectionArgs) {
+    return mAndroidDatabase.rawQuery(sql, selectionArgs);
+  }
+
+  @Override
+  public long insert(String table, String nullColumnHack, ContentValues values) {
+    return mAndroidDatabase.insert(table, nullColumnHack, values);
+  }
+
+  @Override
+  public long insertWithOnConflict(String table, String nullColumnHack, ContentValues initialValues,
+      int conflictAlgorithm) {
+    return mAndroidDatabase
+        .insertWithOnConflict(table, nullColumnHack, initialValues, conflictAlgorithm);
+  }
+
+  @Override
+  public int delete(String table, String whereClause, String[] whereArgs) {
+    return mAndroidDatabase.delete(table, whereClause, whereArgs);
+  }
+
+  @Override
+  public int update(String table, ContentValues values, String whereClause, String[] whereArgs) {
+    return mAndroidDatabase.update(table, values, whereClause, whereArgs);
+  }
+
+  @Override
+  public int updateWithOnConflict(String table, ContentValues values, String whereClause,
+      String[] whereArgs,
+      int conflictAlgorithm) {
+    return mAndroidDatabase
+        .updateWithOnConflict(table, values, whereClause, whereArgs, conflictAlgorithm);
+  }
+
+  @Override
+  public void execSQL(String sql) throws SQLException {
+    mAndroidDatabase.execSQL(sql);
+  }
+
+  @Override
+  public void execSQL(String sql, Object[] bindArgs) throws SQLException {
+    mAndroidDatabase.execSQL(sql, bindArgs);
+  }
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/sqlcipher/SQLiteOpenHelperWrapper.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/sqlcipher/SQLiteOpenHelperWrapper.java
@@ -1,0 +1,36 @@
+package com.squareup.sqlbrite.wrapper.sqlcipher;
+
+import com.squareup.sqlbrite.wrapper.SQLiteDatabase;
+import com.squareup.sqlbrite.wrapper.SQLiteOpenHelper;
+
+import android.support.annotation.Nullable;
+
+public class SQLiteOpenHelperWrapper implements SQLiteOpenHelper {
+
+  private final net.sqlcipher.database.SQLiteOpenHelper mAndroidHelper;
+
+  public SQLiteOpenHelperWrapper(net.sqlcipher.database.SQLiteOpenHelper androidHelper) {
+    mAndroidHelper = androidHelper;
+  }
+
+  @Override
+  public SQLiteDatabase getReadableDatabase(@Nullable String password) {
+    if (password == null) {
+      throw new IllegalStateException("Trying to access an Encrypted database without password.");
+    }
+    return new SQLiteDatabaseWrapper(mAndroidHelper.getReadableDatabase(password));
+  }
+
+  @Override
+  public SQLiteDatabase getWritableDatabase(@Nullable String password) {
+    if (password == null) {
+      throw new IllegalStateException("Trying to access an Encrypted database without password.");
+    }
+    return new SQLiteDatabaseWrapper(mAndroidHelper.getWritableDatabase(password));
+  }
+
+  @Override
+  public void close() {
+    mAndroidHelper.close();
+  }
+}

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/sqlcipher/SQLiteTransactionListenerWrapper.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite/wrapper/sqlcipher/SQLiteTransactionListenerWrapper.java
@@ -1,0 +1,28 @@
+package com.squareup.sqlbrite.wrapper.sqlcipher;
+
+import com.squareup.sqlbrite.wrapper.SQLiteTransactionListener;
+
+public class SQLiteTransactionListenerWrapper
+    implements net.sqlcipher.database.SQLiteTransactionListener {
+
+  private final SQLiteTransactionListener mAndroidListener;
+
+  public SQLiteTransactionListenerWrapper(SQLiteTransactionListener androidListener) {
+    mAndroidListener = androidListener;
+  }
+
+  @Override
+  public void onBegin() {
+    mAndroidListener.onBegin();
+  }
+
+  @Override
+  public void onCommit() {
+    mAndroidListener.onCommit();
+  }
+
+  @Override
+  public void onRollback() {
+    mAndroidListener.onRollback();
+  }
+}


### PR DESCRIPTION
I implemented SQLCipher support by creating wrappers for 
- SQLiteDatabase
- SQLiteOpenHelper
- SQLiteTransactionListener

Unfortunately SQLCipher is using classes that does not extend from Android ones, this is why I was forced to do so to use SQLCipher with sqlbrite.