### PR TITLE
Ensure a group and version is defined for all modules.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,9 @@ allprojects {
   repositories {
     mavenCentral()
   }
+
+  group = GROUP
+  version = VERSION_NAME
 }
 
 ext {


### PR DESCRIPTION
This allows relative project dependencies to appear correctly in the generated Maven pom.

Closes #193.