### PR TITLE
Move emulator startup into Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,17 @@ android:
     - build-tools-25.0.1
     - extra-android-m2repository
     - android-25
-    - sys-img-armeabi-v7a-android-23
+    - sys-img-armeabi-v7a-android-18
 
 jdk:
   - oraclejdk8
+
+before_script:
+  # Create and start an emulator for instrumentation tests.
+  - echo no | android create avd --force -n test -t android-18 --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82
 
 after_success:
   - .buildscript/deploy_snapshot.sh

--- a/gradle/start-emulator.sh
+++ b/gradle/start-emulator.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-echo no | android create avd --force -n test -t android-18 --abi armeabi-v7a
-emulator -avd test -no-skin -no-audio -no-window &
-android-wait-for-emulator
-adb shell input keyevent 82

--- a/sqlbrite/build.gradle
+++ b/sqlbrite/build.gradle
@@ -51,17 +51,4 @@ android {
   }
 }
 
-
-if (isCi()) {
-  println 'Running on CI. Adding task to start emulator.'
-
-  task startEmulator << {
-    "$rootDir/gradle/start-emulator.sh".execute().waitFor()
-  }
-
-  android.testVariants.all { variant ->
-    variant.connectedInstrumentTest.dependsOn startEmulator
-  }
-}
-
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
We're going to have two modules running tests now so this optimization is harder to do (with diminishing returns).