### PR TITLE
API cleanups.

### DIFF
--- a/sample/src/main/java/com/example/sqlbrite/todo/ui/ItemsFragment.java
+++ b/sample/src/main/java/com/example/sqlbrite/todo/ui/ItemsFragment.java
@@ -47,6 +47,7 @@ import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import javax.inject.Inject;
 
+import static android.database.sqlite.SQLiteDatabase.CONFLICT_NONE;
 import static android.support.v4.view.MenuItemCompat.SHOW_AS_ACTION_IF_ROOM;
 import static android.support.v4.view.MenuItemCompat.SHOW_AS_ACTION_WITH_TEXT;
 import static com.squareup.sqlbrite3.SqlBrite.Query;
@@ -141,8 +142,9 @@ public final class ItemsFragment extends Fragment {
         .subscribe(new Consumer<AdapterViewItemClickEvent>() {
           @Override public void accept(AdapterViewItemClickEvent event) {
             boolean newValue = !adapter.getItem(event.position()).complete();
-            db.update(TodoItem.TABLE, new TodoItem.Builder().complete(newValue).build(),
-                TodoItem.ID + " = ?", String.valueOf(event.id()));
+            db.update(TodoItem.TABLE, CONFLICT_NONE,
+                new TodoItem.Builder().complete(newValue).build(), TodoItem.ID + " = ?",
+                String.valueOf(event.id()));
           }
         });
   }

--- a/sample/src/main/java/com/example/sqlbrite/todo/ui/NewItemFragment.java
+++ b/sample/src/main/java/com/example/sqlbrite/todo/ui/NewItemFragment.java
@@ -38,6 +38,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 import javax.inject.Inject;
 
+import static android.database.sqlite.SQLiteDatabase.CONFLICT_NONE;
 import static butterknife.ButterKnife.findById;
 
 public final class NewItemFragment extends DialogFragment {
@@ -79,7 +80,7 @@ public final class NewItemFragment extends DialogFragment {
         .observeOn(Schedulers.io())
         .subscribe(new Consumer<String>() {
           @Override public void accept(String description) {
-            db.insert(TodoItem.TABLE,
+            db.insert(TodoItem.TABLE, CONFLICT_NONE,
                 new TodoItem.Builder().listId(getListId()).description(description).build());
           }
         });

--- a/sample/src/main/java/com/example/sqlbrite/todo/ui/NewListFragment.java
+++ b/sample/src/main/java/com/example/sqlbrite/todo/ui/NewListFragment.java
@@ -38,6 +38,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 import javax.inject.Inject;
 
+import static android.database.sqlite.SQLiteDatabase.CONFLICT_NONE;
 import static butterknife.ButterKnife.findById;
 
 public final class NewListFragment extends DialogFragment {
@@ -68,7 +69,7 @@ public final class NewListFragment extends DialogFragment {
         .observeOn(Schedulers.io())
         .subscribe(new Consumer<String>() {
           @Override public void accept(String name) {
-            db.insert(TodoList.TABLE, new TodoList.Builder().name(name).build());
+            db.insert(TodoList.TABLE, CONFLICT_NONE, new TodoList.Builder().name(name).build());
           }
         });
 

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite3/SqlBrite.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite3/SqlBrite.java
@@ -18,7 +18,6 @@ package com.squareup.sqlbrite3;
 import android.arch.persistence.db.SupportSQLiteOpenHelper;
 import android.content.ContentResolver;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Build;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
@@ -33,14 +32,12 @@ import io.reactivex.ObservableOperator;
 import io.reactivex.ObservableTransformer;
 import io.reactivex.Scheduler;
 import io.reactivex.functions.Function;
-import io.reactivex.subjects.PublishSubject;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
- * A lightweight wrapper around {@link SQLiteOpenHelper} which allows for continuously observing
- * the result of a query.
+ * A lightweight wrapper around {@link SupportSQLiteOpenHelper} which allows for continuously
+ * observing the result of a query.
  */
 public final class SqlBrite {
   static final Logger DEFAULT_LOGGER = new Logger() {
@@ -91,8 +88,8 @@ public final class SqlBrite {
    * Wrap a {@link SupportSQLiteOpenHelper} for observable queries.
    * <p>
    * While not strictly required, instances of this class assume that they will be the only ones
-   * interacting with the underlying {@link SQLiteOpenHelper} and it is required for automatic
-   * notifications of table changes to work. See {@linkplain BriteDatabase#createQuery the
+   * interacting with the underlying {@link SupportSQLiteOpenHelper} and it is required for
+   * automatic notifications of table changes to work. See {@linkplain BriteDatabase#createQuery the
    * <code>query</code> method} for more information on that behavior.
    *
    * @param scheduler The {@link Scheduler} on which items from {@link BriteDatabase#createQuery}
@@ -101,8 +98,7 @@ public final class SqlBrite {
   @CheckResult @NonNull public BriteDatabase wrapDatabaseHelper(
       @NonNull SupportSQLiteOpenHelper helper,
       @NonNull Scheduler scheduler) {
-    PublishSubject<Set<String>> triggers = PublishSubject.create();
-    return new BriteDatabase(helper, logger, triggers, triggers, scheduler, queryTransformer);
+    return new BriteDatabase(helper, logger, scheduler, queryTransformer);
   }
 
   /**


### PR DESCRIPTION
* Remove overloads which did not take a conflict resolution strategy. Force the caller to always specify (matches SupportSQLiteDatabase).
* Remove @RequiresApi(HONEYCOMB) as we're now minSdk = 14.
* Replace Javadoc references from framework classes to support library classes where available.
* Restore use of Subject now that there is no interop bridge.