### PR TITLE
Indent execute() SQL statements in logs.

### DIFF
--- a/sqlbrite/src/androidTest/java/com/squareup/sqlbrite3/BriteDatabaseTest.java
+++ b/sqlbrite/src/androidTest/java/com/squareup/sqlbrite3/BriteDatabaseTest.java
@@ -125,6 +125,50 @@ public final class BriteDatabaseTest {
     assertThat(logs).isEmpty();
   }
 
+  @Test public void loggerIndentsSqlForCreateQuery() {
+    db.setLoggingEnabled(true);
+    QueryObservable query = db.createQuery(TABLE_EMPLOYEE, "SELECT\n1");
+    query.subscribe(new Consumer<Query>() {
+      @Override public void accept(Query query) throws Exception {
+        query.run().close();
+      }
+    });
+    assertThat(logs).containsExactly(""
+        + "QUERY\n"
+        + "  tables: [employee]\n"
+        + "  sql: SELECT\n"
+        + "       1");
+  }
+
+  @Test public void loggerIndentsSqlForQuery() {
+    db.setLoggingEnabled(true);
+    db.query("SELECT\n1").close();
+    assertThat(logs).containsExactly(""
+        + "QUERY\n"
+        + "  sql: SELECT\n"
+        + "       1\n"
+        + "  args: []");
+  }
+
+  @Test public void loggerIndentsSqlForExecute() {
+    db.setLoggingEnabled(true);
+    db.execute("PRAGMA\ncompile_options");
+    assertThat(logs).containsExactly(""
+        + "EXECUTE\n"
+        + "  sql: PRAGMA\n"
+        + "       compile_options");
+  }
+
+  @Test public void loggerIndentsSqlForExecuteWithArgs() {
+    db.setLoggingEnabled(true);
+    db.execute("PRAGMA\ncompile_options", new Object[0]);
+    assertThat(logs).containsExactly(""
+        + "EXECUTE\n"
+        + "  sql: PRAGMA\n"
+        + "       compile_options\n"
+        + "  args: []");
+  }
+
   @Test public void closePropagates() {
     db.close();
     assertThat(real.isOpen()).isFalse();

--- a/sqlbrite/src/main/java/com/squareup/sqlbrite3/BriteDatabase.java
+++ b/sqlbrite/src/main/java/com/squareup/sqlbrite3/BriteDatabase.java
@@ -54,10 +54,8 @@ import static android.database.sqlite.SQLiteDatabase.CONFLICT_NONE;
 import static android.database.sqlite.SQLiteDatabase.CONFLICT_REPLACE;
 import static android.database.sqlite.SQLiteDatabase.CONFLICT_ROLLBACK;
 import static com.squareup.sqlbrite3.QueryObservable.QUERY_OBSERVABLE;
-import static java.lang.System.nanoTime;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 import static java.util.Collections.singletonList;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * A lightweight wrapper around {@link SupportSQLiteOpenHelper} which allows for continuously
@@ -399,12 +397,9 @@ public final class BriteDatabase implements Closeable {
    */
   @CheckResult @WorkerThread
   public Cursor query(@NonNull String sql, @NonNull Object... args) {
-    long startNanos = nanoTime();
     Cursor cursor = getReadableDatabase().query(sql, args);
-    long tookMillis = NANOSECONDS.toMillis(nanoTime() - startNanos);
-
     if (logging) {
-      log("QUERY (%sms)\n  sql: %s\n  args: %s", tookMillis, indentSql(sql), Arrays.toString(args));
+      log("QUERY\n  sql: %s\n  args: %s", indentSql(sql), Arrays.toString(args));
     }
 
     return cursor;
@@ -499,7 +494,7 @@ public final class BriteDatabase implements Closeable {
    */
   @WorkerThread
   public void execute(String sql) {
-    if (logging) log("EXECUTE\n  sql: %s", sql);
+    if (logging) log("EXECUTE\n  sql: %s", indentSql(sql));
 
     getWritableDatabase().execSQL(sql);
   }
@@ -515,7 +510,7 @@ public final class BriteDatabase implements Closeable {
    */
   @WorkerThread
   public void execute(String sql, Object... args) {
-    if (logging) log("EXECUTE\n  sql: %s\n  args: %s", sql, Arrays.toString(args));
+    if (logging) log("EXECUTE\n  sql: %s\n  args: %s", indentSql(sql), Arrays.toString(args));
 
     getWritableDatabase().execSQL(sql, args);
   }
@@ -777,13 +772,10 @@ public final class BriteDatabase implements Closeable {
         throw new IllegalStateException("Cannot execute observable query in a transaction.");
       }
 
-      long startNanos = nanoTime();
       Cursor cursor = getReadableDatabase().query(query);
 
       if (logging) {
-        long tookMillis = NANOSECONDS.toMillis(nanoTime() - startNanos);
-        log("QUERY (%sms)\n  tables: %s\n  sql: %s", tookMillis, tables,
-            indentSql(query.getSql()));
+        log("QUERY\n  tables: %s\n  sql: %s", tables, indentSql(query.getSql()));
       }
 
       return cursor;


### PR DESCRIPTION
Add tests for indents in all 4 arbitrary SQL string methods.

Remove timing of these queries. It's unlikely to reflect any real measure of performance due to internal program caching and lazy windowing of results.