### PR TITLE
Table name lint check

### DIFF
--- a/sqlbrite-lint/src/main/java/com/squareup/sqlbrite3/BriteIssueRegistry.kt
+++ b/sqlbrite-lint/src/main/java/com/squareup/sqlbrite3/BriteIssueRegistry.kt
@@ -19,5 +19,5 @@ import com.android.tools.lint.client.api.IssueRegistry
 
 class BriteIssueRegistry : IssueRegistry() {
 
-  override fun getIssues() = listOf(SqlBriteArgCountDetector.ISSUE)
+  override fun getIssues() = listOf(SqlBriteArgCountDetector.ISSUE, SqlBriteTableDetector.ISSUE)
 }

--- a/sqlbrite-lint/src/main/java/com/squareup/sqlbrite3/SqlBriteTableDetector.kt
+++ b/sqlbrite-lint/src/main/java/com/squareup/sqlbrite3/SqlBriteTableDetector.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqlbrite3
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.ConstantEvaluator.evaluateString
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+import java.util.*
+
+private const val CREATE_QUERY_METHOD_NAME = "createQuery"
+private const val BRITE_DATABASE = "com.squareup.sqlbrite3.BriteDatabase"
+
+class SqlBriteTableDetector : Detector(), Detector.UastScanner {
+
+    companion object {
+        val ISSUE = Issue.create("SqlBriteTableName",
+                "One or more of the tables provided is not in the query statement",
+                "All the tables passed in the first parameter must exist in the query statement",
+                Category.MESSAGES,
+                8,
+                Severity.ERROR,
+                Implementation(SqlBriteTableDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES))
+                )
+    }
+
+    override fun getApplicableMethodNames() = listOf(CREATE_QUERY_METHOD_NAME)
+
+    override fun visitMethod(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        val evaluator = context.evaluator
+
+        if (evaluator.isMemberInClass(method, BRITE_DATABASE)) {
+            // Skip the signature createQuery(DatabaseQuery query)
+            if (node.valueArgumentCount < 2) return
+
+            val arguments = node.valueArguments
+
+            val tableName = evaluateString(context, arguments[0], true)
+            val query = evaluateString(context, arguments[1], true)
+
+
+            // Skipping list of tables for now
+            if (tableName != null && query != null) {
+                if (!query.toString().contains(tableName.toString(), true)) {
+                    context.report(ISSUE, node, context.getLocation(node), "Invalid table name " +
+                            "in query statement. Query statement, '$query' should contain table name : " +
+                            " $tableName")
+                }
+            }
+        }
+    }
+
+}

--- a/sqlbrite-lint/src/test/java/com/squareup/sqlbrite3/SqlBriteTableDetectorTest.kt
+++ b/sqlbrite-lint/src/test/java/com/squareup/sqlbrite3/SqlBriteTableDetectorTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqlbrite3
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestFiles.java
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+
+class SqlBriteTableDetectorTest {
+
+    companion object {
+        private val BRITE_DATABASE_STUB = TestFiles.java(
+                """
+      package com.squareup.sqlbrite3;
+
+      public final class BriteDatabase {
+
+
+        public void createQuery(String table, String sql, Object... args) {
+        }
+
+      }
+      """.trimIndent()
+        )
+    }
+
+    @Test fun usingValidTableName() {
+        lint().files(
+                BRITE_DATABASE_STUB,
+                java("""
+                    package test.pkg;
+
+                    import com.squareup.sqlbrite3.BriteDatabase;
+
+                    public class Test {
+                        private static final String TABLE = "actual_table";
+                        private static final String QUERY = "SELECT * from " + TABLE;
+
+                        public void test() {
+                            BriteDatabase db = new BriteDatabase();
+                            db.createQuery(TABLE, QUERY);
+                        }
+
+                    }
+                """.trimIndent()))
+                .issues(SqlBriteTableDetector.ISSUE)
+                .run()
+                .expectClean()
+    }
+
+    @Test fun usingValidTableNameWithArgs() {
+        lint().files(
+                BRITE_DATABASE_STUB,
+                java("""
+                    package test.pkg;
+
+                    import com.squareup.sqlbrite3.BriteDatabase;
+
+                    public class Test {
+                        private static final String TABLE = "actual_table";
+                        private static final String QUERY = "SELECT * from " + TABLE + " WHERE id = ?";
+
+                        public void test() {
+                            BriteDatabase db = new BriteDatabase();
+                            db.createQuery(TABLE, QUERY, "id");
+                        }
+
+                    }
+                """.trimIndent()))
+                .issues(SqlBriteTableDetector.ISSUE)
+                .run()
+                .expectClean()
+    }
+
+    @Test fun usingInvalidTableName() {
+        lint().files(
+                BRITE_DATABASE_STUB,
+                java("""
+                    package test.pkg;
+
+                    import com.squareup.sqlbrite3.BriteDatabase;
+
+                    public class Test {
+                        private static final String TABLE = "actual_table";
+                        private static final String QUERY = "SELECT * from other_table";
+
+                        public void test() {
+                            BriteDatabase db = new BriteDatabase();
+                            db.createQuery(TABLE, QUERY);
+                        }
+
+                    }
+                """.trimIndent()))
+                .issues(SqlBriteTableDetector.ISSUE)
+                .run()
+                .expect("src/test/pkg/Test.java:11: " +
+                        "Error: Invalid table name in query statement. Query statement, " +
+                        "'SELECT * from other_table' should contain table name :  actual_table [SqlBriteTableName]\n" +
+                        "        db.createQuery(TABLE, QUERY);\n" +
+                        "        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                        "1 errors, 0 warnings\n")
+    }
+}

--- a/sqlbrite-lint/src/test/java/com/squareup/sqlbrite3/SqlBriteTableDetectorTest.kt
+++ b/sqlbrite-lint/src/test/java/com/squareup/sqlbrite3/SqlBriteTableDetectorTest.kt
@@ -115,4 +115,34 @@ class SqlBriteTableDetectorTest {
                         "        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
                         "1 errors, 0 warnings\n")
     }
+
+    @Test fun usingInvalidTableNameWithArgs() {
+        lint().files(
+                BRITE_DATABASE_STUB,
+                java("""
+                    package test.pkg;
+
+                    import com.squareup.sqlbrite3.BriteDatabase;
+
+                    public class Test {
+                        private static final String TABLE = "actual_table";
+                        private static final String QUERY = "SELECT * from other_table WHERE id = ?";
+
+                        public void test() {
+                            BriteDatabase db = new BriteDatabase();
+                            db.createQuery(TABLE, QUERY, "id");
+                        }
+
+                    }
+                """.trimIndent()))
+                .issues(SqlBriteTableDetector.ISSUE)
+                .run()
+                .expect("src/test/pkg/Test.java:11: " +
+                        "Error: Invalid table name in query statement. Query statement, " +
+                        "'SELECT * from other_table WHERE id = ?' should contain table name :  actual_table [SqlBriteTableName]\n" +
+                        "        db.createQuery(TABLE, QUERY, \"id\");\n" +
+                        "        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                        "1 errors, 0 warnings\n")
+    }
+
 }

--- a/sqlbrite-lint/src/test/java/com/squareup/sqlbrite3/SqlBriteTableDetectorTest.kt
+++ b/sqlbrite-lint/src/test/java/com/squareup/sqlbrite3/SqlBriteTableDetectorTest.kt
@@ -23,9 +23,9 @@ import org.junit.Test
 
 class SqlBriteTableDetectorTest {
 
-    companion object {
-        private val BRITE_DATABASE_STUB = TestFiles.java(
-                """
+  companion object {
+    private val BRITE_DATABASE_STUB = TestFiles.java(
+            """
       package com.squareup.sqlbrite3;
 
       public final class BriteDatabase {
@@ -36,113 +36,118 @@ class SqlBriteTableDetectorTest {
 
       }
       """.trimIndent()
-        )
-    }
+    )
+  }
 
-    @Test fun usingValidTableName() {
-        lint().files(
-                BRITE_DATABASE_STUB,
-                java("""
-                    package test.pkg;
+  @Test
+  fun usingValidTableName() {
+    lint().files(
+            BRITE_DATABASE_STUB,
+            java("""
+              package test.pkg;
+              import com.squareup.sqlbrite3.BriteDatabase;
 
-                    import com.squareup.sqlbrite3.BriteDatabase;
+              public class Test {
 
-                    public class Test {
-                        private static final String TABLE = "actual_table";
-                        private static final String QUERY = "SELECT * from " + TABLE;
+                private static final String TABLE = "actual_table";
+                private static final String QUERY = "SELECT * from " + TABLE;
 
-                        public void test() {
-                            BriteDatabase db = new BriteDatabase();
-                            db.createQuery(TABLE, QUERY);
-                        }
+                public void test() {
+                  BriteDatabase db = new BriteDatabase();
+                  db.createQuery(TABLE, QUERY);
+                }
 
-                    }
-                """.trimIndent()))
-                .issues(SqlBriteTableDetector.ISSUE)
-                .run()
-                .expectClean()
-    }
+              }
+              """.trimIndent()))
+            .issues(SqlBriteTableDetector.ISSUE)
+            .run()
+            .expectClean()
+  }
 
-    @Test fun usingValidTableNameWithArgs() {
-        lint().files(
-                BRITE_DATABASE_STUB,
-                java("""
-                    package test.pkg;
+  @Test
+  fun usingValidTableNameWithArgs() {
+    lint().files(
+            BRITE_DATABASE_STUB,
+            java("""
+              package test.pkg;
 
-                    import com.squareup.sqlbrite3.BriteDatabase;
+              import com.squareup.sqlbrite3.BriteDatabase;
 
-                    public class Test {
-                        private static final String TABLE = "actual_table";
-                        private static final String QUERY = "SELECT * from " + TABLE + " WHERE id = ?";
+              public class Test {
 
-                        public void test() {
-                            BriteDatabase db = new BriteDatabase();
-                            db.createQuery(TABLE, QUERY, "id");
-                        }
+                private static final String TABLE = "actual_table";
+                private static final String QUERY = "SELECT * from " + TABLE + " WHERE id = ?";
 
-                    }
-                """.trimIndent()))
-                .issues(SqlBriteTableDetector.ISSUE)
-                .run()
-                .expectClean()
-    }
+                public void test() {
+                  BriteDatabase db = new BriteDatabase();
+                  db.createQuery(TABLE, QUERY, "id");
+                }
 
-    @Test fun usingInvalidTableName() {
-        lint().files(
-                BRITE_DATABASE_STUB,
-                java("""
-                    package test.pkg;
+              }
+              """.trimIndent()))
+            .issues(SqlBriteTableDetector.ISSUE)
+            .run()
+            .expectClean()
+  }
 
-                    import com.squareup.sqlbrite3.BriteDatabase;
+  @Test
+  fun usingInvalidTableName() {
+    lint().files(
+            BRITE_DATABASE_STUB,
+            java("""
+              package test.pkg;
 
-                    public class Test {
-                        private static final String TABLE = "actual_table";
-                        private static final String QUERY = "SELECT * from other_table";
+              import com.squareup.sqlbrite3.BriteDatabase;
 
-                        public void test() {
-                            BriteDatabase db = new BriteDatabase();
-                            db.createQuery(TABLE, QUERY);
-                        }
+              public class Test {
+                private static final String TABLE = "actual_table";
+                private static final String QUERY = "SELECT * from other_table";
 
-                    }
-                """.trimIndent()))
-                .issues(SqlBriteTableDetector.ISSUE)
-                .run()
-                .expect("src/test/pkg/Test.java:11: " +
-                        "Error: Invalid table name in query statement. Query statement, " +
-                        "'SELECT * from other_table' should contain table name :  actual_table [SqlBriteTableName]\n" +
-                        "        db.createQuery(TABLE, QUERY);\n" +
-                        "        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-                        "1 errors, 0 warnings\n")
-    }
+                public void test() {
+                  BriteDatabase db = new BriteDatabase();
+                  db.createQuery(TABLE, QUERY);
+                }
 
-    @Test fun usingInvalidTableNameWithArgs() {
-        lint().files(
-                BRITE_DATABASE_STUB,
-                java("""
-                    package test.pkg;
+              }
+              """.trimIndent()))
+            .issues(SqlBriteTableDetector.ISSUE)
+            .run()
+            .expect("src/test/pkg/Test.java:11: " +
+                    "Error: Invalid table name in query statement. Query statement, " +
+                    "'SELECT * from other_table' should contain table name :  actual_table [SqlBriteTableName]\n" +
+                    "    db.createQuery(TABLE, QUERY);\n" +
+                    "    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                    "1 errors, 0 warnings\n")
+  }
 
-                    import com.squareup.sqlbrite3.BriteDatabase;
+  @Test
+  fun usingInvalidTableNameWithArgs() {
+    lint().files(
+            BRITE_DATABASE_STUB,
+            java("""
+              package test.pkg;
 
-                    public class Test {
-                        private static final String TABLE = "actual_table";
-                        private static final String QUERY = "SELECT * from other_table WHERE id = ?";
+              import com.squareup.sqlbrite3.BriteDatabase;
 
-                        public void test() {
-                            BriteDatabase db = new BriteDatabase();
-                            db.createQuery(TABLE, QUERY, "id");
-                        }
+              public class Test {
+                private static final String TABLE = "actual_table";
+                private static final String QUERY = "SELECT * from other_table WHERE id = ?";
 
-                    }
-                """.trimIndent()))
-                .issues(SqlBriteTableDetector.ISSUE)
-                .run()
-                .expect("src/test/pkg/Test.java:11: " +
-                        "Error: Invalid table name in query statement. Query statement, " +
-                        "'SELECT * from other_table WHERE id = ?' should contain table name :  actual_table [SqlBriteTableName]\n" +
-                        "        db.createQuery(TABLE, QUERY, \"id\");\n" +
-                        "        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-                        "1 errors, 0 warnings\n")
-    }
+                public void test() {
+                  BriteDatabase db = new BriteDatabase();
+                  db.createQuery(TABLE, QUERY, "id");
+                }
+
+              }
+              """.trimIndent()))
+            .issues(SqlBriteTableDetector.ISSUE)
+            .run()
+            .expect("src/test/pkg/Test.java:11: " +
+                    "Error: Invalid table name in query statement. Query statement, " +
+                    "'SELECT * from other_table WHERE id = ?' should contain table name :  actual_table [SqlBriteTableName]\n" +
+                    "    db.createQuery(TABLE, QUERY, \"id\");\n" +
+                    "    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                    "1 errors, 0 warnings\n")
+  }
 
 }


### PR DESCRIPTION
#58 
I've added a lint check to make sure that table name being passed in `createQuery` actually exists in the SQL query. 

This doesn't yet cover checking for list of tables or SupportSQLiteQuery. I had a hard time finding documentation to evaluate values of lists. 
